### PR TITLE
Include missing migrations

### DIFF
--- a/cli/build_aws-s3.go
+++ b/cli/build_aws-s3.go
@@ -3,5 +3,5 @@
 package main
 
 import (
-	_ "github.com/golang-migrate/migrate/source/aws-s3"
+	_ "github.com/basekit/migrate/source/aws-s3"
 )

--- a/cli/build_cassandra.go
+++ b/cli/build_cassandra.go
@@ -3,5 +3,5 @@
 package main
 
 import (
-	_ "github.com/golang-migrate/migrate/database/cassandra"
+	_ "github.com/basekit/migrate/database/cassandra"
 )

--- a/cli/build_clickhouse.go
+++ b/cli/build_clickhouse.go
@@ -4,5 +4,5 @@ package main
 
 import (
 	_ "github.com/kshvakov/clickhouse"
-	_ "github.com/golang-migrate/migrate/database/clickhouse"
+	_ "github.com/basekit/migrate/database/clickhouse"
 )

--- a/cli/build_cockroachdb.go
+++ b/cli/build_cockroachdb.go
@@ -3,5 +3,5 @@
 package main
 
 import (
-	_ "github.com/golang-migrate/migrate/database/cockroachdb"
+	_ "github.com/basekit/migrate/database/cockroachdb"
 )

--- a/cli/build_github.go
+++ b/cli/build_github.go
@@ -3,5 +3,5 @@
 package main
 
 import (
-	_ "github.com/golang-migrate/migrate/source/github"
+	_ "github.com/basekit/migrate/source/github"
 )

--- a/cli/build_go-bindata.go
+++ b/cli/build_go-bindata.go
@@ -3,5 +3,5 @@
 package main
 
 import (
-	_ "github.com/golang-migrate/migrate/source/go-bindata"
+	_ "github.com/basekit/migrate/source/go-bindata"
 )

--- a/cli/build_google-cloud-storage.go
+++ b/cli/build_google-cloud-storage.go
@@ -3,5 +3,5 @@
 package main
 
 import (
-	_ "github.com/golang-migrate/migrate/source/google-cloud-storage"
+	_ "github.com/basekit/migrate/source/google-cloud-storage"
 )

--- a/cli/build_mysql.go
+++ b/cli/build_mysql.go
@@ -3,5 +3,5 @@
 package main
 
 import (
-	_ "github.com/golang-migrate/migrate/database/mysql"
+	_ "github.com/basekit/migrate/database/mysql"
 )

--- a/cli/build_postgres.go
+++ b/cli/build_postgres.go
@@ -3,5 +3,5 @@
 package main
 
 import (
-	_ "github.com/golang-migrate/migrate/database/postgres"
+	_ "github.com/basekit/migrate/database/postgres"
 )

--- a/cli/build_ql.go
+++ b/cli/build_ql.go
@@ -3,5 +3,5 @@
 package main
 
 import (
-	_ "github.com/golang-migrate/migrate/database/ql"
+	_ "github.com/basekit/migrate/database/ql"
 )

--- a/cli/build_redshift.go
+++ b/cli/build_redshift.go
@@ -3,5 +3,5 @@
 package main
 
 import (
-	_ "github.com/golang-migrate/migrate/database/redshift"
+	_ "github.com/basekit/migrate/database/redshift"
 )

--- a/cli/build_spanner.go
+++ b/cli/build_spanner.go
@@ -3,5 +3,5 @@
 package main
 
 import (
-	_ "github.com/golang-migrate/migrate/database/spanner"
+	_ "github.com/basekit/migrate/database/spanner"
 )

--- a/cli/build_sqlite3.go
+++ b/cli/build_sqlite3.go
@@ -3,5 +3,5 @@
 package main
 
 import (
-	_ "github.com/golang-migrate/migrate/database/sqlite3"
+	_ "github.com/basekit/migrate/database/sqlite3"
 )

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -3,9 +3,9 @@ package main
 import (
 	"errors"
 	"fmt"
-	"github.com/golang-migrate/migrate"
-	_ "github.com/golang-migrate/migrate/database/stub" // TODO remove again
-	_ "github.com/golang-migrate/migrate/source/file"
+	"github.com/basekit/migrate"
+	_ "github.com/basekit/migrate/database/stub" // TODO remove again
+	_ "github.com/basekit/migrate/source/file"
 	"os"
 	"path/filepath"
 	"strconv"

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -99,7 +99,7 @@ func gotoCmd(m *migrate.Migrate, v uint) {
 	}
 }
 
-func upCmd(m *migrate.Migrate, limit int) {
+func upCmd(m *migrate.Migrate, limit int, includeMissing bool) {
 	if limit >= 0 {
 		if err := m.Steps(limit); err != nil {
 			if err != migrate.ErrNoChange {
@@ -109,7 +109,7 @@ func upCmd(m *migrate.Migrate, limit int) {
 			}
 		}
 	} else {
-		if err := m.Up(); err != nil {
+		if err := m.Up(includeMissing); err != nil {
 			if err != migrate.ErrNoChange {
 				log.fatalErr(err)
 			} else {

--- a/cli/main.go
+++ b/cli/main.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/golang-migrate/migrate"
+	"github.com/basekit/migrate"
 )
 
 // set main log

--- a/database/cassandra/cassandra.go
+++ b/database/cassandra/cassandra.go
@@ -197,6 +197,10 @@ func (c *Cassandra) Version() (version int, dirty bool, err error) {
 	}
 }
 
+func (c *Cassandra) GetAllVersions() (versions map[string]bool, err error) {
+	return versions, err
+}
+
 func (c *Cassandra) Drop() error {
 	// select all tables in current schema
 	query := fmt.Sprintf(`SELECT table_name from system_schema.tables WHERE keyspace_name='%s'`, c.config.KeyspaceName)

--- a/database/cassandra/cassandra.go
+++ b/database/cassandra/cassandra.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/gocql/gocql"
-	"github.com/golang-migrate/migrate/database"
+	"github.com/basekit/migrate/database"
 )
 
 func init() {

--- a/database/cassandra/cassandra_test.go
+++ b/database/cassandra/cassandra_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/gocql/gocql"
 
-	dt "github.com/golang-migrate/migrate/database/testing"
-	mt "github.com/golang-migrate/migrate/testing"
+	dt "github.com/basekit/migrate/database/testing"
+	mt "github.com/basekit/migrate/testing"
 )
 
 var versions = []mt.Version{

--- a/database/clickhouse/clickhouse.go
+++ b/database/clickhouse/clickhouse.go
@@ -8,8 +8,8 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/golang-migrate/migrate"
-	"github.com/golang-migrate/migrate/database"
+	"github.com/basekit/migrate"
+	"github.com/basekit/migrate/database"
 )
 
 var DefaultMigrationsTable = "schema_migrations"

--- a/database/clickhouse/clickhouse.go
+++ b/database/clickhouse/clickhouse.go
@@ -118,6 +118,10 @@ func (ch *ClickHouse) Version() (int, bool, error) {
 	return version, dirty == 1, nil
 }
 
+func (ch *ClickHouse) GetAllVersions() (versions map[string]bool, err error) {
+	return versions, err
+}
+
 func (ch *ClickHouse) SetVersion(version int, dirty bool) error {
 	var (
 		bool = func(v bool) uint8 {

--- a/database/cockroachdb/cockroachdb.go
+++ b/database/cockroachdb/cockroachdb.go
@@ -265,6 +265,10 @@ func (c *CockroachDb) Version() (version int, dirty bool, err error) {
 	}
 }
 
+func (c *CockroachDb) GetAllVersions() (versions map[string]bool, err error) {
+	return versions, err
+}
+
 func (c *CockroachDb) Drop() error {
 	// select all tables in current schema
 	query := `SELECT table_name FROM information_schema.tables WHERE table_schema=(SELECT current_schema())`

--- a/database/cockroachdb/cockroachdb.go
+++ b/database/cockroachdb/cockroachdb.go
@@ -17,8 +17,8 @@ import (
 )
 
 import (
-	"github.com/golang-migrate/migrate"
-	"github.com/golang-migrate/migrate/database"
+	"github.com/basekit/migrate"
+	"github.com/basekit/migrate/database"
 )
 
 func init() {

--- a/database/cockroachdb/cockroachdb_test.go
+++ b/database/cockroachdb/cockroachdb_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"github.com/lib/pq"
-	dt "github.com/golang-migrate/migrate/database/testing"
-	mt "github.com/golang-migrate/migrate/testing"
+	dt "github.com/basekit/migrate/database/testing"
+	mt "github.com/basekit/migrate/testing"
 	"bytes"
 )
 

--- a/database/driver.go
+++ b/database/driver.go
@@ -73,6 +73,9 @@ type Driver interface {
 	// Dirty means, a previous migration failed and user interaction is required.
 	Version() (version int, dirty bool, err error)
 
+	// GetAllVersions returns all the stored versions
+	GetAllVersions() (versions map[string]bool, err error)
+
 	// Drop deletes everything in the database.
 	Drop() error
 }

--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -15,8 +15,8 @@ import (
 	"strings"
 
 	"github.com/go-sql-driver/mysql"
-	"github.com/golang-migrate/migrate"
-	"github.com/golang-migrate/migrate/database"
+	"github.com/basekit/migrate"
+	"github.com/basekit/migrate/database"
 )
 
 func init() {

--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -265,6 +265,24 @@ func (m *Mysql) Version() (version int, dirty bool, err error) {
 	}
 }
 
+func (m *Mysql) GetAllVersions() (versions map[string]bool, err error) {
+	query := "SELECT * FROM `" + m.config.MigrationsTable + "`"
+	migrations, err := m.conn.QueryContext(context.Background(), query)
+	if err != nil {
+		return nil, &database.Error{OrigErr: err, Query: []byte(query)}
+	}
+	defer migrations.Close()
+	for migrations.Next() {
+		var versionNumber string
+		var dirty bool
+		if err := migrations.Scan(&versionNumber, &dirty); err != nil {
+			return nil, err
+		}
+		versions[versionNumber] = dirty
+	}
+	return versions, nil
+}
+
 func (m *Mysql) Drop() error {
 	// select all tables
 	query := `SHOW TABLES LIKE '%'`

--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -230,15 +230,9 @@ func (m *Mysql) SetVersion(version int, dirty bool) error {
 		return &database.Error{OrigErr: err, Err: "transaction start failed"}
 	}
 
-	query := "TRUNCATE `" + m.config.MigrationsTable + "`"
-	if _, err := tx.ExecContext(context.Background(), query); err != nil {
-		tx.Rollback()
-		return &database.Error{OrigErr: err, Query: []byte(query)}
-	}
-
 	if version >= 0 {
-		query := "INSERT INTO `" + m.config.MigrationsTable + "` (version, dirty) VALUES (?, ?)"
-		if _, err := tx.ExecContext(context.Background(), query, version, dirty); err != nil {
+		query := "INSERT INTO `" + m.config.MigrationsTable + "` (version, dirty) VALUES (?, ?) ON DUPLICATE KEY UPDATE dirty = ?"
+		if _, err := tx.ExecContext(context.Background(), query, version, dirty, dirty); err != nil {
 			tx.Rollback()
 			return &database.Error{OrigErr: err, Query: []byte(query)}
 		}

--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -246,7 +246,7 @@ func (m *Mysql) SetVersion(version int, dirty bool) error {
 }
 
 func (m *Mysql) Version() (version int, dirty bool, err error) {
-	query := "SELECT version, dirty FROM `" + m.config.MigrationsTable + "` LIMIT 1"
+	query := "SELECT version, dirty FROM `" + m.config.MigrationsTable + "` ORDER BY version DESC LIMIT 1"
 	err = m.conn.QueryRowContext(context.Background(), query).Scan(&version, &dirty)
 	switch {
 	case err == sql.ErrNoRows:

--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -271,6 +271,7 @@ func (m *Mysql) GetAllVersions() (versions map[string]bool, err error) {
 	if err != nil {
 		return nil, &database.Error{OrigErr: err, Query: []byte(query)}
 	}
+	versions = make(map[string]bool)
 	defer migrations.Close()
 	for migrations.Next() {
 		var versionNumber string

--- a/database/mysql/mysql_test.go
+++ b/database/mysql/mysql_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"github.com/go-sql-driver/mysql"
-	dt "github.com/golang-migrate/migrate/database/testing"
-	mt "github.com/golang-migrate/migrate/testing"
+	dt "github.com/basekit/migrate/database/testing"
+	mt "github.com/basekit/migrate/testing"
 )
 
 var versions = []mt.Version{

--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -221,6 +221,10 @@ func (p *Postgres) Version() (version int, dirty bool, err error) {
 	}
 }
 
+func (p *Postgres) GetAllVersions() (versions map[string]bool, err error) {
+	return versions, err
+}
+
 func (p *Postgres) Drop() error {
 	// select all tables in current schema
 	query := `SELECT table_name FROM information_schema.tables WHERE table_schema=(SELECT current_schema())`

--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -10,8 +10,8 @@ import (
 	nurl "net/url"
 
 	"context"
-	"github.com/golang-migrate/migrate"
-	"github.com/golang-migrate/migrate/database"
+	"github.com/basekit/migrate"
+	"github.com/basekit/migrate/database"
 	"github.com/lib/pq"
 )
 

--- a/database/postgres/postgres_test.go
+++ b/database/postgres/postgres_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 
 	"context"
-	dt "github.com/golang-migrate/migrate/database/testing"
-	mt "github.com/golang-migrate/migrate/testing"
+	dt "github.com/basekit/migrate/database/testing"
+	mt "github.com/basekit/migrate/testing"
 	// "github.com/lib/pq"
 )
 

--- a/database/ql/ql.go
+++ b/database/ql/ql.go
@@ -10,8 +10,8 @@ import (
 	nurl "net/url"
 
 	_ "github.com/cznic/ql/driver"
-	"github.com/golang-migrate/migrate"
-	"github.com/golang-migrate/migrate/database"
+	"github.com/basekit/migrate"
+	"github.com/basekit/migrate/database"
 )
 
 func init() {

--- a/database/ql/ql_test.go
+++ b/database/ql/ql_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 
 	_ "github.com/cznic/ql/driver"
-	"github.com/golang-migrate/migrate"
-	dt "github.com/golang-migrate/migrate/database/testing"
-	_ "github.com/golang-migrate/migrate/source/file"
+	"github.com/basekit/migrate"
+	dt "github.com/basekit/migrate/database/testing"
+	_ "github.com/basekit/migrate/source/file"
 )
 
 func Test(t *testing.T) {

--- a/database/redshift/redshift.go
+++ b/database/redshift/redshift.go
@@ -3,8 +3,8 @@ package redshift
 import (
 	"net/url"
 
-	"github.com/golang-migrate/migrate/database"
-	"github.com/golang-migrate/migrate/database/postgres"
+	"github.com/basekit/migrate/database"
+	"github.com/basekit/migrate/database/postgres"
 )
 
 // init registers the driver under the name 'redshift'

--- a/database/spanner/spanner.go
+++ b/database/spanner/spanner.go
@@ -204,6 +204,10 @@ func (s *Spanner) Version() (version int, dirty bool, err error) {
 	return version, dirty, nil
 }
 
+func (s *Spanner) GetAllVersions() (versions map[string]bool, err error) {
+	return versions, err
+}
+
 // Drop implements database.Driver. Retrieves the database schema first and
 // creates statements to drop the indexes and tables accordingly.
 // Note: The drop statements are created in reverse order to how they're

--- a/database/spanner/spanner.go
+++ b/database/spanner/spanner.go
@@ -14,8 +14,8 @@ import (
 	"cloud.google.com/go/spanner"
 	sdb "cloud.google.com/go/spanner/admin/database/apiv1"
 
-	"github.com/golang-migrate/migrate"
-	"github.com/golang-migrate/migrate/database"
+	"github.com/basekit/migrate"
+	"github.com/basekit/migrate/database"
 
 	"google.golang.org/api/iterator"
 	adminpb "google.golang.org/genproto/googleapis/spanner/admin/database/v1"

--- a/database/spanner/spanner_test.go
+++ b/database/spanner/spanner_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	dt "github.com/golang-migrate/migrate/database/testing"
+	dt "github.com/basekit/migrate/database/testing"
 )
 
 func Test(t *testing.T) {

--- a/database/sqlite3/sqlite3.go
+++ b/database/sqlite3/sqlite3.go
@@ -3,8 +3,8 @@ package sqlite3
 import (
 	"database/sql"
 	"fmt"
-	"github.com/golang-migrate/migrate"
-	"github.com/golang-migrate/migrate/database"
+	"github.com/basekit/migrate"
+	"github.com/basekit/migrate/database"
 	_ "github.com/mattn/go-sqlite3"
 	"io"
 	"io/ioutil"

--- a/database/sqlite3/sqlite3_test.go
+++ b/database/sqlite3/sqlite3_test.go
@@ -3,9 +3,9 @@ package sqlite3
 import (
 	"database/sql"
 	"fmt"
-	"github.com/golang-migrate/migrate"
-	dt "github.com/golang-migrate/migrate/database/testing"
-	_ "github.com/golang-migrate/migrate/source/file"
+	"github.com/basekit/migrate"
+	dt "github.com/basekit/migrate/database/testing"
+	_ "github.com/basekit/migrate/source/file"
 	_ "github.com/mattn/go-sqlite3"
 	"io/ioutil"
 	"os"

--- a/database/stub/stub.go
+++ b/database/stub/stub.go
@@ -81,6 +81,10 @@ func (s *Stub) Version() (version int, dirty bool, err error) {
 	return s.CurrentVersion, s.IsDirty, nil
 }
 
+func (s *Stub) GetAllVersions() (versions map[string]bool, err error) {
+	return versions, err
+}
+
 const DROP = "DROP"
 
 func (s *Stub) Drop() error {

--- a/database/stub/stub.go
+++ b/database/stub/stub.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"reflect"
 
-	"github.com/golang-migrate/migrate/database"
+	"github.com/basekit/migrate/database"
 )
 
 func init() {

--- a/database/stub/stub_test.go
+++ b/database/stub/stub_test.go
@@ -3,7 +3,7 @@ package stub
 import (
 	"testing"
 
-	dt "github.com/golang-migrate/migrate/database/testing"
+	dt "github.com/basekit/migrate/database/testing"
 )
 
 func Test(t *testing.T) {

--- a/database/testing/testing.go
+++ b/database/testing/testing.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang-migrate/migrate/database"
+	"github.com/basekit/migrate/database"
 )
 
 // Test runs tests against database implementations.

--- a/migrate.go
+++ b/migrate.go
@@ -10,8 +10,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang-migrate/migrate/database"
-	"github.com/golang-migrate/migrate/source"
+	"github.com/basekit/migrate/database"
+	"github.com/basekit/migrate/source"
 )
 
 // DefaultPrefetchMigrations sets the number of migrations to pre-read

--- a/migrate.go
+++ b/migrate.go
@@ -276,13 +276,25 @@ func (m *Migrate) Up(includeMissing bool) error {
 		if err != nil {
 			return m.unlockErr(err)
 		}
+
+		firstVersion := 0
+		firstDirty := false
 		if (len(allVersions) > 0) {
 			for k, v := range allVersions {
 				curVersion, _ = strconv.Atoi(k)
 				dirty = v
-				break
+				// throw error if any versions are dirty
+				if dirty {
+					return m.unlockErr(ErrDirty{curVersion})
+				}
+				if firstVersion == 0 {
+					firstVersion = curVersion
+					firstDirty = dirty
+				}
 			}
 		}
+		curVersion = firstVersion
+		dirty = firstDirty
 	}
 
 	if err != nil {

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -8,9 +8,9 @@ import (
 	"os"
 	"testing"
 
-	dStub "github.com/golang-migrate/migrate/database/stub"
-	"github.com/golang-migrate/migrate/source"
-	sStub "github.com/golang-migrate/migrate/source/stub"
+	dStub "github.com/basekit/migrate/database/stub"
+	"github.com/basekit/migrate/source"
+	sStub "github.com/basekit/migrate/source/stub"
 )
 
 // sourceStubMigrations hold the following migrations:
@@ -104,7 +104,7 @@ func ExampleNewWithDatabaseInstance() {
 
 	// Create driver instance from db.
 	// Check each driver if it supports the WithInstance function.
-	// `import "github.com/golang-migrate/migrate/database/postgres"`
+	// `import "github.com/basekit/migrate/database/postgres"`
 	instance, err := dStub.WithInstance(db, &dStub.Config{})
 	if err != nil {
 		log.Fatal(err)
@@ -154,7 +154,7 @@ func ExampleNewWithSourceInstance() {
 
 	// Create driver instance from DummyInstance di.
 	// Check each driver if it support the WithInstance function.
-	// `import "github.com/golang-migrate/migrate/source/stub"`
+	// `import "github.com/basekit/migrate/source/stub"`
 	instance, err := sStub.WithInstance(di, &sStub.Config{})
 	if err != nil {
 		log.Fatal(err)

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -62,7 +62,7 @@ func ExampleNew() {
 	}
 
 	// Migrate all the way up ...
-	if err := m.Up(); err != nil {
+	if err := m.Up(false); err != nil {
 		log.Fatal(err)
 	}
 }
@@ -117,7 +117,7 @@ func ExampleNewWithDatabaseInstance() {
 	}
 
 	// Migrate all the way up ...
-	if err := m.Up(); err != nil {
+	if err := m.Up(false); err != nil {
 		log.Fatal(err)
 	}
 }
@@ -167,7 +167,7 @@ func ExampleNewWithSourceInstance() {
 	}
 
 	// Migrate all the way up ...
-	if err := m.Up(); err != nil {
+	if err := m.Up(false); err != nil {
 		log.Fatal(err)
 	}
 }
@@ -382,7 +382,7 @@ func TestUpAndDown(t *testing.T) {
 	seq := newMigSeq()
 
 	// go Up first
-	if err := m.Up(); err != nil {
+	if err := m.Up(false); err != nil {
 		t.Fatal(err)
 	}
 	equalDbSeq(t, 0, seq.add(M(1), M(3), M(4), M(5), M(7)), dbDrv)
@@ -397,7 +397,7 @@ func TestUpAndDown(t *testing.T) {
 	if err := m.Steps(1); err != nil {
 		t.Fatal(err)
 	}
-	if err := m.Up(); err != nil {
+	if err := m.Up(false); err != nil {
 		t.Fatal(err)
 	}
 	equalDbSeq(t, 2, seq.add(M(1), M(3), M(4), M(5), M(7)), dbDrv)
@@ -419,7 +419,7 @@ func TestUpDirty(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := m.Up()
+	err := m.Up(false)
 	if _, ok := err.(ErrDirty); !ok {
 		t.Fatalf("expected ErrDirty, got %v", err)
 	}
@@ -751,7 +751,7 @@ func TestReadUp(t *testing.T) {
 
 	for i, v := range tt {
 		ret := make(chan interface{})
-		go m.readUp(v.from, v.limit, ret)
+		go m.readUp(v.from, v.limit, ret, false)
 		migrations, err := migrationsFromChannel(ret)
 
 		if (v.expectErr == os.ErrNotExist && !os.IsNotExist(err)) ||

--- a/source/aws-s3/s3.go
+++ b/source/aws-s3/s3.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
-	"github.com/golang-migrate/migrate/source"
+	"github.com/basekit/migrate/source"
 )
 
 func init() {

--- a/source/aws-s3/s3_test.go
+++ b/source/aws-s3/s3_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/golang-migrate/migrate/source"
-	st "github.com/golang-migrate/migrate/source/testing"
+	"github.com/basekit/migrate/source"
+	st "github.com/basekit/migrate/source/testing"
 )
 
 func Test(t *testing.T) {

--- a/source/file/file.go
+++ b/source/file/file.go
@@ -9,7 +9,7 @@ import (
 	"path"
 	"path/filepath"
 
-	"github.com/golang-migrate/migrate/source"
+	"github.com/basekit/migrate/source"
 )
 
 func init() {

--- a/source/file/file_test.go
+++ b/source/file/file_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	st "github.com/golang-migrate/migrate/source/testing"
+	st "github.com/basekit/migrate/source/testing"
 )
 
 func Test(t *testing.T) {

--- a/source/github/github.go
+++ b/source/github/github.go
@@ -11,7 +11,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/golang-migrate/migrate/source"
+	"github.com/basekit/migrate/source"
 	"github.com/google/go-github/github"
 )
 

--- a/source/github/github_test.go
+++ b/source/github/github_test.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	st "github.com/golang-migrate/migrate/source/testing"
+	st "github.com/basekit/migrate/source/testing"
 )
 
 var GithubTestSecret = "" // username:token

--- a/source/go-bindata/go-bindata.go
+++ b/source/go-bindata/go-bindata.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/golang-migrate/migrate/source"
+	"github.com/basekit/migrate/source"
 )
 
 type AssetFunc func(name string) ([]byte, error)

--- a/source/go-bindata/go-bindata_test.go
+++ b/source/go-bindata/go-bindata_test.go
@@ -3,8 +3,8 @@ package bindata
 import (
 	"testing"
 
-	"github.com/golang-migrate/migrate/source/go-bindata/testdata"
-	st "github.com/golang-migrate/migrate/source/testing"
+	"github.com/basekit/migrate/source/go-bindata/testdata"
+	st "github.com/basekit/migrate/source/testing"
 )
 
 func Test(t *testing.T) {

--- a/source/google-cloud-storage/storage.go
+++ b/source/google-cloud-storage/storage.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"cloud.google.com/go/storage"
-	"github.com/golang-migrate/migrate/source"
+	"github.com/basekit/migrate/source"
 	"golang.org/x/net/context"
 	"google.golang.org/api/iterator"
 )

--- a/source/google-cloud-storage/storage_test.go
+++ b/source/google-cloud-storage/storage_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/fsouza/fake-gcs-server/fakestorage"
-	"github.com/golang-migrate/migrate/source"
-	st "github.com/golang-migrate/migrate/source/testing"
+	"github.com/basekit/migrate/source"
+	st "github.com/basekit/migrate/source/testing"
 )
 
 func Test(t *testing.T) {

--- a/source/stub/stub.go
+++ b/source/stub/stub.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/golang-migrate/migrate/source"
+	"github.com/basekit/migrate/source"
 )
 
 func init() {

--- a/source/stub/stub_test.go
+++ b/source/stub/stub_test.go
@@ -3,8 +3,8 @@ package stub
 import (
 	"testing"
 
-	"github.com/golang-migrate/migrate/source"
-	st "github.com/golang-migrate/migrate/source/testing"
+	"github.com/basekit/migrate/source"
+	st "github.com/basekit/migrate/source/testing"
 )
 
 func Test(t *testing.T) {

--- a/source/testing/testing.go
+++ b/source/testing/testing.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/golang-migrate/migrate/source"
+	"github.com/basekit/migrate/source"
 )
 
 // Test runs tests against source implementations.


### PR DESCRIPTION
- Only been implemented for mysql so far.
- All migrations are stored.
- Use `-include-missing=true` with the `up` command to run any migrations which exist on the file system which are currently not stored in the `schema_migrations` table.

## Testing

- Setup test DB
- Add some migration files
- `make build-cli`
- `cd cli/build`
- Run binary such as `./migrate.darwin-amd64 -path 'PATH_TO_FILES' -database 'mysql://DB_USER@tcp(DB_HOST_IP:DB_PORT)/migrate_test' up --include-missing=true`
